### PR TITLE
fix: error when received model don't have headers

### DIFF
--- a/django_outbox_pattern/models.py
+++ b/django_outbox_pattern/models.py
@@ -58,7 +58,7 @@ class Received(models.Model):
 
     @property
     def destination(self):
-        return self.headers.get("destination")
+        return self.headers.get("destination", "") if self.headers else ""
 
     class Meta:
         verbose_name = "received"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-outbox-pattern"
-version = "0.12.0"
+version = "0.12.1"
 description = "A django application to make it easier to use the transactional outbox pattern"
 license = "MIT"
 authors = ["Hugo Brilhante <hugobrilhante@gmail.com>"]

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,17 @@
+from django.test import TransactionTestCase
+
+from django_outbox_pattern.models import Received
+
+
+class ReceivedTest(TransactionTestCase):
+    def test_received_should_return_destination_empty_when_object_have_headers_none(self):
+        received = Received()
+        self.assertEqual("", received.destination)
+
+    def test_received_should_return_destination_value_when_have_headers(self):
+        received = Received(headers={"destination": "fake"})
+        self.assertEqual("fake", received.destination)
+
+    def test_received_should_return_destination_empty_when_object_have_headers_but_without_key_destination(self):
+        received = Received(headers={"fake": "fake"})
+        self.assertEqual("", received.destination)


### PR DESCRIPTION
The current implementation of the destination property only returns an empty string or the value of the destination header. 