### PR TITLE
feat: The system will remove messages that are more than 30 days old.

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,3 +368,19 @@ constants provided by the ssl module. The default is ssl.PROTOCOL_TLSv1.
 **DEFAULT_STOMP_SSL_PASSWORD**
 
 SSL password
+
+**DAYS_TO_KEEP_DATA**
+
+The total number of days that the system will keep a message in the database history. Default: 30
+
+**REMOVE_DATA_CACHE_TTL**
+
+This variable defines the time-to-live (TTL) value in seconds for the cache used by the `_remove_old_messages` method in the `django_outbox_pattern` application. The cache is used to prevent the method from deleting old data every time it is run, and the TTL value determines how long the cache entry should remain valid before being automatically deleted. It can be customized by setting the REMOVE_DATA_CACHE_TTL variable. Default: 86400 seconds (1 day)
+
+**OUTBOX_PATTERN_PUBLISHER_CACHE_KEY**
+
+The `OUTBOX_PATTERN_PUBLISHER_CACHE_KEY` variable controls the key name of the cache used to store the outbox pattern publisher. Default: `remove_old_messages_django_outbox_pattern_publisher`.
+
+**OUTBOX_PATTERN_CONSUMER_CACHE_KEY**
+
+The `OUTBOX_PATTERN_CONSUMER_CACHE_KEY` variable controls the key name of the cache used to store the outbox pattern publisher. Default: `remove_old_messages_django_outbox_pattern_consumer`.

--- a/django_outbox_pattern/settings.py
+++ b/django_outbox_pattern/settings.py
@@ -37,6 +37,10 @@ DEFAULTS = {
     "DEFAULT_STOMP_CERT_VALIDATOR": None,
     "DEFAULT_STOMP_SSL_VERSION": None,
     "DEFAULT_STOMP_SSL_PASSWORD": None,
+    "DAYS_TO_KEEP_DATA": 30,
+    "REMOVE_DATA_CACHE_TTL": 86400,
+    "OUTBOX_PATTERN_PUBLISHER_CACHE_KEY": "remove_old_messages_django_outbox_pattern_publisher",
+    "OUTBOX_PATTERN_CONSUMER_CACHE_KEY": "remove_old_messages_django_outbox_pattern_consumer",
 }
 
 # List of settings that may be in string import notation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-outbox-pattern"
-version = "0.12.1"
+version = "0.13.0"
 description = "A django application to make it easier to use the transactional outbox pattern"
 license = "MIT"
 authors = ["Hugo Brilhante <hugobrilhante@gmail.com>"]

--- a/tests/integration/test_consumer.py
+++ b/tests/integration/test_consumer.py
@@ -1,8 +1,15 @@
+from datetime import datetime
+from datetime import timedelta
+from time import sleep
+from unittest import mock
+
+from django.core.cache import cache
 from django.test import TransactionTestCase
 from stomp.listener import TestListener
 
 from django_outbox_pattern.factories import factory_consumer
 from django_outbox_pattern.models import Received
+from django_outbox_pattern.settings import settings
 
 
 def get_callback(raise_except=False):
@@ -20,11 +27,14 @@ class ConsumerTest(TransactionTestCase):
         self.consumer.set_listener("test_listener", TestListener(print_to_log=True))
         self.listener = self.consumer.get_listener("test_listener")
 
+    def tearDown(self) -> None:
+        cache.delete(settings.OUTBOX_PATTERN_CONSUMER_CACHE_KEY)
+
     def test_when_message_handler_no_raise_exception(self):
         destination = "/topic/consumer.v0"
         callback = get_callback()
         self.consumer.start(callback, destination)
-        self.consumer.connection.send(destination=destination, body='{"message": "Message test no raise"}')
+        self.consumer.connection.send(destination=destination, body='{"message": "mock message"}')
         self.listener.wait_for_message()
         received_message = self.listener.get_latest_message()
         assert received_message is not None
@@ -74,3 +84,61 @@ class ConsumerTest(TransactionTestCase):
         self.listener.wait_on_disconnected()
         self.assertEqual(1, self.listener.connections)
         self.assertEqual(1, self.listener.disconnects)
+
+    def test_consumer_message_should_remove_old_messages(self):
+        self._create_message_in_the_past(31, 1)
+        self._create_message_in_the_past(31, 2)
+        self._create_message_in_the_past(31, 3)
+        self._create_message_in_the_past(30, 4)
+        self._create_message_in_the_past(29, 5)
+        self._create_message_in_the_past(29, 6)
+
+        destination = "/topic/consumer.v4"
+        callback = get_callback()
+
+        self.consumer.start(callback, destination)
+        self.consumer.connection.send(destination=destination, body='{"message": "Message Body"}')
+        self.listener.wait_for_message()
+        received_message = self.listener.get_latest_message()
+
+        assert received_message is not None
+        self.assertEqual(1, self.listener.connections)
+        self.assertEqual(1, self.listener.messages)
+        count_message = Received.objects.all().count()
+        self.assertEqual(3, count_message)
+        self.assertFalse(self.consumer.received_class.objects.filter(msg_id=1).exists())
+        self.assertFalse(self.consumer.received_class.objects.filter(msg_id=2).exists())
+        self.assertFalse(self.consumer.received_class.objects.filter(msg_id=3).exists())
+        self.assertFalse(self.consumer.received_class.objects.filter(msg_id=4).exists())
+
+    def test_consumer_should_not_remove_old_message_when_cache_exists(self):
+        self._create_message_in_the_past(35, 1)
+        self.consumer._remove_old_messages()  # pylint: disable=W0212
+        self.assertFalse(self.consumer.received_class.objects.filter(msg_id=1).exists())
+        self._create_message_in_the_past(35, 2)
+        self.consumer._remove_old_messages()  # pylint: disable=W0212
+        self.assertTrue(self.consumer.received_class.objects.filter(msg_id=2).exists())
+
+    def _create_message_in_the_past(self, day_ago, msg_id):
+        now = datetime.now()
+        date_days_ago = now - timedelta(days=day_ago)
+        self.consumer.received_class(body={}, headers={}, msg_id=msg_id, added=date_days_ago).save()
+        message = self.consumer.received_class.objects.filter(msg_id=msg_id).first()
+        message.added = date_days_ago
+        message.save()
+
+    @mock.patch("django_outbox_pattern.consumers.cache")
+    def test_consumer_should_consume_message_event_if_a_exception_happen_in_cache(self, mock_cache):
+        mock_cache.get.side_effect = Exception("Cache get failed")
+        destination = "/topic/consumer.v5"
+        callback = get_callback()
+        self.consumer.start(callback, destination)
+        with self.assertRaises(Exception):
+            self.consumer.connection.send(destination=destination, body='{"message": "Message test no raise"}')
+            sleep(1)
+            self.listener.get_latest_message()
+
+        count_message = Received.objects.all().count()
+        self.assertEqual(1, count_message)
+
+        mock_cache.get.assert_called_once_with(settings.OUTBOX_PATTERN_CONSUMER_CACHE_KEY)

--- a/tests/integration/test_prodeucer.py
+++ b/tests/integration/test_prodeucer.py
@@ -1,13 +1,23 @@
 import json
+from datetime import datetime
+from datetime import timedelta
+from unittest import mock
 
+from django.core.cache import cache
 from django.test import TestCase
 from stomp.listener import TestListener
 
 from django_outbox_pattern.factories import factory_producer
 from django_outbox_pattern.models import Published
+from django_outbox_pattern.settings import settings
 
 
 class ProducerTest(TestCase):
+    fake_destination = "/topic/destination_send_event_context"
+
+    def tearDown(self) -> None:
+        cache.delete(settings.OUTBOX_PATTERN_PUBLISHER_CACHE_KEY)
+
     def test_producer_send(self):
         some_body = {"message": "Message test"}
         some_destination = "/topic/destination"
@@ -36,7 +46,7 @@ class ProducerTest(TestCase):
         assert received_body == some_body
 
     def test_producer_send_event(self):
-        some_body = {"message": "Test send event"}
+        some_body = {"message": "fake body"}
         some_destination = "/topic/destination_send_event"
         producer = factory_producer()
         producer.set_listener("test_listener", TestListener(print_to_log=True))
@@ -64,12 +74,73 @@ class ProducerTest(TestCase):
     def test_producer_send_event_with_context_manager(self):
         with factory_producer() as producer:
             producer.set_listener("test_listener", TestListener(print_to_log=True))
-            producer.connection.subscribe(destination="/topic/destination_send_event_context", id=1)
+            producer.connection.subscribe(destination=self.fake_destination, id=1)
             listener = producer.get_listener("test_listener")
-            producer.send_event(
-                destination="/topic/destination_send_event_context", body={"message": "Test send event"}
-            )
+            producer.send_event(destination=self.fake_destination, body={"message": "fake message body"})
             listener.wait_for_message()
         listener.wait_on_disconnected()
         self.assertEqual(1, listener.messages)
         self.assertEqual(1, listener.disconnects)
+
+    def test_producer_should_remove_old_messages(self):
+        ms1 = self._create_message_in_the_past(31)
+        ms2 = self._create_message_in_the_past(31)
+        ms3 = self._create_message_in_the_past(31)
+        ms4 = self._create_message_in_the_past(30)
+        ms5 = self._create_message_in_the_past(29)
+        ms6 = self._create_message_in_the_past(29)
+
+        with factory_producer() as producer:
+            producer.set_listener("test_listener", TestListener(print_to_log=True))
+            producer.connection.subscribe(destination=self.fake_destination, id=1)
+            listener = producer.get_listener("test_listener")
+            producer.send_event(destination=self.fake_destination, body={"message": "Test send event"})
+            listener.wait_for_message()
+        listener.wait_on_disconnected()
+        self.assertEqual(1, listener.messages)
+        self.assertEqual(1, listener.disconnects)
+
+        self.assertFalse(Published.objects.filter(id=ms1.id).exists())
+        self.assertFalse(Published.objects.filter(id=ms2.id).exists())
+        self.assertFalse(Published.objects.filter(id=ms3.id).exists())
+        self.assertFalse(Published.objects.filter(id=ms4.id).exists())
+        self.assertTrue(Published.objects.filter(id=ms5.id).exists())
+        self.assertTrue(Published.objects.filter(id=ms6.id).exists())
+
+        self.assertEqual(2, Published.objects.count())
+
+    def test_consumer_should_not_remove_old_message_when_cache_exists(self):
+        message = self._create_message_in_the_past(31)
+        producer = factory_producer()
+        producer._remove_old_messages()  # pylint: disable=W0212
+        self.assertFalse(Published.objects.filter(id=message.id).exists())
+        message1 = self._create_message_in_the_past(31)
+        producer._remove_old_messages()  # pylint: disable=W0212
+        self.assertTrue(Published.objects.filter(id=message1.id).exists())
+
+    @mock.patch("django_outbox_pattern.producers.cache")
+    def test_producer_should_send_message_event_if_a_exception_happen_in_cache(self, mock_cache):
+        mock_cache.get.side_effect = Exception("Cache get failed")
+        with factory_producer() as producer:
+            producer.set_listener("test_listener", TestListener(print_to_log=True))
+            producer.connection.subscribe(destination=self.fake_destination, id=1)
+            listener = producer.get_listener("test_listener")
+            with self.assertRaises(Exception):
+                producer.send_event(destination=self.fake_destination, body={"message": "fake message body"})
+
+            listener.wait_for_message()
+
+        listener.wait_on_disconnected()
+        self.assertEqual(1, listener.messages)
+        self.assertEqual(1, listener.disconnects)
+
+        mock_cache.get.assert_called_once_with(settings.OUTBOX_PATTERN_PUBLISHER_CACHE_KEY)
+
+    def _create_message_in_the_past(self, day_ago):
+        now = datetime.now()
+        date_days_ago = now - timedelta(days=day_ago)
+        message = Published(body={})
+        message.save()
+        message.added = date_days_ago
+        message.save()
+        return message


### PR DESCRIPTION
The library logs every message in the database to guarantee the outbox and idempotency patterns. Without a logic to clean these tables, the library will use a lot of space in the database, which is not the intended purpose of the library. The default behavior is to maintain all messages that are less than 30 days old in the database and remove the messages after that.

The PR includes tests and updates to the documentation.