### PR TITLE
feat: add stop param to method save

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,24 @@ This generates the following data to be sent.
 Published(destination='/topic/my_route_key_1', body='{"id": 1, "one": "Field One"}')
 Published(destination='/topic/my_route_key_2', body='{"id": 1, "two": "Field Two"}')
 ```
+## Stopping Publication
+
+The `@publish` decorator adds a named parameter called `stop` to the `save` method, which is useful when you need to update an instance of a decorated model and do not want this update to be published on the broker.
+```python
+from django.db import transaction
+from django_outbox_pattern.payloads import Payload
+
+from .models import Order
+
+def callback(payload: Payload):
+    order_id = payload.body["order_id"]
+    status = payload.body["status"]
+    with transaction.atomic():
+        order = Order.objects.get(order_id=order_id)
+        order.status = status
+        order.save(stop=True)
+        payload.save()
+```
 
 ## Publish/Subscribe commands
 

--- a/django_outbox_pattern/decorators.py
+++ b/django_outbox_pattern/decorators.py
@@ -1,3 +1,4 @@
+# pylint: disable=protected-access
 import json
 from typing import List
 from typing import NamedTuple
@@ -17,17 +18,24 @@ class Config(NamedTuple):
 
 
 def publish(configs: List[Config]):
-    def save(self, *args, **kwargs):
-        with transaction.atomic():
-            super(self.__class__, self).save(*args, **kwargs)
-            for config in configs:
-                _create_published(self, *config)
+    def wrapper(cls):
+        class PublishModel(cls):
+            def save(self, *args, stop=False, **kwargs):
+                with transaction.atomic():
+                    super().save(*args, **kwargs)
+                    if not stop:
+                        for config in configs:
+                            _create_published(self, *config)
 
-    def decorator_publish(cls):
-        cls.save = save
-        return cls
+            class Meta(getattr(cls, "Meta", object)):
+                proxy = True
+                app_label = cls._meta.app_label
+                verbose_name = cls._meta.verbose_name
+                verbose_name_plural = cls._meta.verbose_name_plural
 
-    return decorator_publish
+        return PublishModel
+
+    return wrapper
 
 
 def _create_published(obj, destination, fields, serializer, version):


### PR DESCRIPTION
Sometimes you need to update an instance of a model decorated with @publish, but you don't want a new message to be published on the broker.

An example, which may serve as a guideline to understand the motivation behind this new feature, would be updating the status of an order when it reaches its final stage:

```python
order = Order.objects.get(order_id=order_id)
order.status = 'Confirmed'
order.save(stop=True)
```

In this example, by using `stop=True` when calling the `save` method, the message publication on the broker is halted, allowing the update of the order status without triggering a new publication message.

This pull request also incorporates the changes from the fix in pull request PR #42 