### PR TITLE
fix(migration): adjust index retrocompatibility name

### DIFF
--- a/django_outbox_pattern/models.py
+++ b/django_outbox_pattern/models.py
@@ -34,7 +34,7 @@ class Published(models.Model):
         verbose_name = "published"
         db_table = "published"
         indexes = [
-            models.Index(fields=["status"]),
+            models.Index(fields=["status"], name="published_status_27c9ec_btree"),
         ]
 
     def __str__(self):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - djangooutboxpattern
 
   rabbitmq:
-    image : rabbitmq:3-management
+    image : rabbitmq:4-management
     volumes:
        - ./tests/resources/rabbitmq:/etc/rabbitmq/
     healthcheck:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-outbox-pattern"
-version = "3.0.1"
+version = "3.0.2"
 description = "A django application to make it easier to use the transactional outbox pattern"
 license = "MIT"
 authors = ["Hugo Brilhante <hugobrilhante@gmail.com>"]


### PR DESCRIPTION
# Infos

## [Implementação do OTEL nas apps Python](https://juntossomosmais.monday.com/boards/3957397225/pulses/8884474644)

### What is being delivered?

After the [PR 73](https://github.com/juntossomosmais/django-outbox-pattern/pull/73) to not use specific postgres indexes the django are generating a new migration 007 trying to rename the index.
To maintain the backward compatibility for atual applied index and not generate the migration 007, the current index name is included in the `models.Index` declaration.

Without this name one migration 007 will be generated and one drop index and recreate can be dangerous for the database, depending on its size can stop the application.



