### PR TITLE
feat(publish): adjusts in publish function

### DIFF
--- a/django_outbox_pattern/management/commands/publish.py
+++ b/django_outbox_pattern/management/commands/publish.py
@@ -1,34 +1,17 @@
 import logging
 import sys
 
-from datetime import timedelta
-from time import sleep
-
 from django.core.management.base import BaseCommand
-from django.db import DatabaseError
-from django.utils import timezone
-from django.utils.module_loading import import_string
 
-from django_outbox_pattern import settings
-from django_outbox_pattern.choices import StatusChoice
-from django_outbox_pattern.exceptions import ExceededSendAttemptsException
 from django_outbox_pattern.factories import factory_producer
 
 _logger = logging.getLogger("django_outbox_pattern")
-
-
-def _waiting():
-    sleep(settings.DEFAULT_PRODUCER_WAITING_TIME)
 
 
 class Command(BaseCommand):
     help = "Publish command"
     running = True
     producer = factory_producer()
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.published_class = import_string(settings.DEFAULT_PUBLISHED_CLASS)
 
     def handle(self, *args, **options):
         try:
@@ -43,37 +26,4 @@ class Command(BaseCommand):
     def _publish(self):
         _logger.info("Waiting for messages to be published 😋.")
         while self.running:
-            try:
-                objects_to_publish = self.published_class.objects.filter(
-                    status=StatusChoice.SCHEDULE, expires_at__gte=timezone.now()
-                )
-                if not objects_to_publish.exists():
-                    _logger.debug("No objects to publish")
-                    _waiting()
-                    continue
-
-                published = objects_to_publish.iterator(chunk_size=settings.DEFAULT_PUBLISHED_CHUNK_SIZE)
-                self.producer.start()
-                for message in published:
-                    message_id = message.id
-                    _logger.debug("Message to published with body: %s", message.body)
-                    try:
-                        attempts = self.producer.send(message)
-                    except ExceededSendAttemptsException as exc:
-                        _logger.exception("Exceeded send attempts")
-                        message.retry = exc.attempts
-                        message.status = StatusChoice.FAILED
-                        message.expires_at = timezone.now() + timedelta(15)
-                        _logger.info(f"Message no published with id: {message_id}")
-                    else:
-                        message.retry = attempts
-                        message.status = StatusChoice.SUCCEEDED
-                        _logger.info(f"Message published with id: {message_id}")
-                    finally:
-                        message.save()
-                self.producer.stop()
-            except DatabaseError:
-                _logger.info("Starting publisher 🤔.")
-                _waiting()
-            else:
-                _waiting()
+            self.producer.publish_message_from_database()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-outbox-pattern"
-version = "3.0.6"
+version = "3.0.7"
 description = "A django application to make it easier to use the transactional outbox pattern"
 license = "MIT"
 authors = ["Hugo Brilhante <hugobrilhante@gmail.com>"]


### PR DESCRIPTION
# Infos

## [fix publicador django-outbox-pattern](https://juntossomosmais.monday.com/boards/3957397225/pulses/10018465288)

### What is being delivered?

- Update README about heartbeat in publisher
- Trace Problem:
    - When we look the instrumentation for this process, the long running command with infinite looping `while running` causes confusion in traces. The context for all libs instrumentation (psycopg, django, outbox) not get correctly the traces nothing reflected the reality.

<img width="2016" height="1562" alt="Screenshot 2025-09-11 at 16 45 21" src="https://github.com/user-attachments/assets/e1a5d110-a8d2-45a5-971e-e08aae32e5a1" />
    
- Possible Solution:
   - Removed the publish logic from management command including this logic inside Producer class removing some abstraction and make the code little more functional looking instrumentation for the library.
   - With these changes + outbox instrumentation changes we can see process of publication reflexing the reality, for each second one `SELECT` are made in database to get Published objects. 

<img width="1458" height="792" alt="Screenshot 2025-09-12 at 10 59 00" src="https://github.com/user-attachments/assets/c8faee44-9037-4852-a9fe-dbd83311d07e" />



